### PR TITLE
fix(docs): search result support scroll to anchor

### DIFF
--- a/docs/Masa.Docs.Server/Properties/launchSettings.json
+++ b/docs/Masa.Docs.Server/Properties/launchSettings.json
@@ -1,15 +1,6 @@
 {
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5000"
-    },
-    "https": {
+    "kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/docs/Masa.Docs.Shared/wwwroot/js/docs.js
+++ b/docs/Masa.Docs.Shared/wwwroot/js/docs.js
@@ -440,7 +440,9 @@ window.addDocSearch = function (index, currentLanguage, placeholder) {
             }
             if (document.location.pathname === hitUrl.pathname) {
               if (hitUrl.hash) {
-                window.scrollToElement(hitUrl.hash.substring(1), 108);
+                window.requestAnimationFrame(() =>
+                  window.scrollToElement(hitUrl.hash.substring(1), 108)
+                );
               } else {
                 window.backTop();
               }


### PR DESCRIPTION
1. search document in same page
2. search use link to another page(it is some thing like )
3. use same config support http and https