### PR TITLE
🐛 fix(AppCodeGroup): use `text-none` css for the tab content

### DIFF
--- a/docs/Masa.Docs.Core/Components/AppCodeGroup.razor
+++ b/docs/Masa.Docs.Core/Components/AppCodeGroup.razor
@@ -6,7 +6,7 @@
     <MTabs @bind-Value="_tabValue" Class="mb-1">
         @foreach (var tab in Tabs)
         {
-            <MTab Class="text-capitalize">@tab</MTab>
+            <MTab Class="text-none">@tab</MTab>
         }
     </MTabs>
 


### PR DESCRIPTION
resolves masastack/MASA.Docs#148