### PR TITLE
🆕 feat(ECharts): support for verbatim text of function string

### DIFF
--- a/src/Masa.Blazor/Components/ECharts/MECharts.razor.cs
+++ b/src/Masa.Blazor/Components/ECharts/MECharts.razor.cs
@@ -202,9 +202,18 @@ public partial class MECharts : BDomComponentBase, IEChartsJsCallbacks, IAsyncDi
 
         if (IncludeFunctionsInOption && IsAnyFunction(option, out var optionJson))
         {
+            // unescape verbatim text
+            optionJson = Regex.Unescape(optionJson);
+
+            // remove the double quotes around the function
             optionJson = FormatFunction(optionJson);
+
+            // remove the double quotes around the lambda
             optionJson = FormatLambda(optionJson);
+
+            // convert unicode to string
             optionJson = Unicode2String(optionJson);
+
             await _echarts.SetJsonOptionAsync(optionJson, notMerge, lazyUpdate);
         }
         else
@@ -232,6 +241,7 @@ public partial class MECharts : BDomComponentBase, IEChartsJsCallbacks, IAsyncDi
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
 
+        // check if the option contains "function" or "=>"
         return optionJson.Contains("function") || optionJson.Contains("=\\u003e", StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
Supported usage:
```cs
var option = new {
    renderItem = @"
        ...
    ";
}
```