### PR TITLE
🆕 feat(pop-up): support for persistence of pop-up windows when using SSR

### DIFF
--- a/src/Masa.Blazor/Components/Dialog/MDialog.cs
+++ b/src/Masa.Blazor/Components/Dialog/MDialog.cs
@@ -15,6 +15,13 @@
         [Parameter]
         public string? OverlayScrimClass { get; set; }
 
+        /// <summary>
+        /// The lazy content would be created in a [data-permanent] element.
+        /// It's useful when you use this component in a layout.
+        /// </summary>
+        [Parameter]
+        public bool Permanent { get; set; }
+
         [Parameter]
         public bool Scrollable { get; set; }
 
@@ -42,7 +49,8 @@
 
         bool IDialog.IsBooted => IsBooted;
 
-        protected override string AttachSelector => Attach ?? ".m-application";
+        protected override string AttachSelector
+            => Attach ?? (Permanent ? ".m-application__permanent" : ".m-application");
 
         protected override bool IsFullscreen => Fullscreen && MasaBlazor.Breakpoint.SmAndDown;
 

--- a/src/Masa.Blazor/Components/Menu/MMenu.cs
+++ b/src/Masa.Blazor/Components/Menu/MMenu.cs
@@ -4,7 +4,7 @@ namespace Masa.Blazor
 {
     public class MMenu : BMenu
     {
-        protected override string DefaultAttachSelector => ".m-application";
+        protected override string DefaultAttachSelector => Permanent ? ".m-application__permanent" : ".m-application";
 
         public override IEnumerable<string> DependentSelectors
             => base.DependentSelectors.Concat(new[] { MSnackbar.ROOT_CSS_SELECTOR, PEnqueuedSnackbars.ROOT_CSS_SELECTOR }).Distinct();

--- a/src/Masa.Blazor/Components/Tooltip/MTooltip.cs
+++ b/src/Masa.Blazor/Components/Tooltip/MTooltip.cs
@@ -5,7 +5,7 @@
         [Parameter]
         public string? ContentStyle { get; set; }
 
-        protected override string DefaultAttachSelector => ".m-application";
+        protected override string DefaultAttachSelector => Permanent ? ".m-application__permanent" : ".m-application";
 
         ElementReference ITooltip.ContentElement
         {


### PR DESCRIPTION
Using `Permenant` parameter in Dialog/Menu/Tooltip components can prevent the failure of the page from popping up after a jump. Usually need to use this parameter on a layout component.