### PR TITLE
add init data and loadData event callback to be init

### DIFF
--- a/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
+++ b/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
@@ -8,7 +8,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
 
     [Parameter] public DrawflowEditorMode Mode { get; set; }
 
-    [Parameter] public Func<Task<string>>? DataInitializer { get; set; }
+    [Parameter] public Func<ValueTask<string>>? DataInitializer { get; set; }
 
     [Parameter] public EventCallback<string> OnNodeCreated { get; set; }
 
@@ -25,7 +25,6 @@ public class MDrawflow : MDrop, IAsyncDisposable
     private DrawflowEditorMode? _prevMode;
     private IDrawflowJSObjectReferenceProxy? _drawflowProxy;
     private DotNetObjectReference<object>? _interopHandleReference;
-    private string? _data;
 
     protected override string ClassString => new Block("m-drawflow").Modifier(Mode, "mode").AddClass(base.ClassString).Build();
 
@@ -53,13 +52,15 @@ public class MDrawflow : MDrop, IAsyncDisposable
 
             if (DataInitializer != null)
             {
-                _data = await DataInitializer.Invoke();
+                 var data = await DataInitializer.Invoke();
+
+                 if (!string.IsNullOrWhiteSpace(data))
+                 {
+                     await _drawflowProxy!.ImportAsync(data);
+                 }
             }
 
-            if (!string.IsNullOrEmpty(_data))
-            {
-                await _drawflowProxy!.ImportAsync(_data);
-            }
+            
         }
     }
 

--- a/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
+++ b/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
@@ -8,7 +8,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
 
     [Parameter] public DrawflowEditorMode Mode { get; set; }
 
-    [Parameter] public Func<string>? DataInitializer { get; set; }
+    [Parameter] public Func<Task<string>>? DataInitializer { get; set; }
 
     [Parameter] public EventCallback<string> OnNodeCreated { get; set; }
 
@@ -41,7 +41,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
 
         if (DataInitializer != null)
         {
-            _data = DataInitializer.Invoke();
+            _data = await DataInitializer.Invoke();
         }
     }
 

--- a/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
+++ b/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
@@ -39,10 +39,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
             _drawflowProxy?.SetMode(Mode);
         }
 
-        if (DataInitializer != null)
-        {
-            _data = await DataInitializer.Invoke();
-        }
+        
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -53,7 +50,12 @@ public class MDrawflow : MDrop, IAsyncDisposable
         { 
             _interopHandleReference = DotNetObjectReference.Create<object>(new DrawflowInteropHandle(this));
             _drawflowProxy = await DrawflowJSModule.Init(ElementReference.GetSelector()!, _interopHandleReference, Mode);
-            
+
+            if (DataInitializer != null)
+            {
+                _data = await DataInitializer.Invoke();
+            }
+
             if (!string.IsNullOrEmpty(_data))
             {
                 await _drawflowProxy!.ImportAsync(_data);

--- a/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
+++ b/src/Masa.Blazor/Components/Drawflow/MDrawflow.cs
@@ -8,6 +8,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
 
     [Parameter] public DrawflowEditorMode Mode { get; set; }
 
+    [Parameter] public string? Data { get; set; }
     [Parameter] public EventCallback<string> OnNodeCreated { get; set; }
 
     [Parameter] public EventCallback<string> OnNodeRemoved { get; set; }
@@ -17,6 +18,7 @@ public class MDrawflow : MDrop, IAsyncDisposable
     [Parameter] public EventCallback<string> OnNodeUnselected { get; set; }
 
     [Parameter] public EventCallback<string> OnNodeDataChanged { get; set; }
+    [Parameter]public EventCallback LoadData { get; set; }
 
     [Parameter] public EventCallback OnImport { get; set; }
 
@@ -45,6 +47,16 @@ public class MDrawflow : MDrop, IAsyncDisposable
         { 
             _interopHandleReference = DotNetObjectReference.Create<object>(new DrawflowInteropHandle(this));
             _drawflowProxy = await DrawflowJSModule.Init(ElementReference.GetSelector()!, _interopHandleReference, Mode);
+
+            if (LoadData.HasDelegate)
+            {
+                await LoadData.InvokeAsync();
+            }
+
+            if (!string.IsNullOrEmpty(Data))
+            {
+                await _drawflowProxy!.ImportAsync(Data);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

因为当_drawflowProxy = await DrawflowJSModule.Init(ElementReference.GetSelector()!, _interopHandleReference, Mode);执行后,页面相关dom元素才会被渲染以及事件发生挂钩对接,若当有基础dataflow的json数据,这时候是无法初始化的,增加初始json数据参数以及loadData的event callback,协助初始化,不需要在first render的方法内进行delay.....等待相关dom渲染完成后再初始化控件的json数据..

