### PR TITLE
🐛 fix(TextField): failed to modify the Value in ValueChanged

### DIFF
--- a/docs/Masa.Blazor.Docs/Examples/components/text-fields/PasswordInput.razor
+++ b/docs/Masa.Blazor.Docs/Examples/components/text-fields/PasswordInput.razor
@@ -4,7 +4,7 @@
             Cols="12"
             Sm="6">
             <MTextField
-                @bind-Value="password"
+                @bind-Value="hintText"
                 AppendIcon="@(show1 ? "mdi-eye" : "mdi-eye-off")"
                 Rules="RequiredAndMinRule"
                 Type="@(show1 ? "text" : "password")"
@@ -27,7 +27,7 @@
                 Label="Visible"
                 Hint="At least 8 characters"
                 TValue="string"
-                Value="@("wqfasds")"
+                @bind-Value="@visible"
                 Class="input-group--focused"
                 OnAppendClick="() => show2 = !show2">
             </MTextField>
@@ -43,7 +43,7 @@
                 Name="input-10-2"
                 Label="Not visible"
                 Hint="At least 8 characters"
-                Value="@("wqfasds")"
+                @bind-Value="@notVisible"
                 Class="input-group--focused"
                 OnAppendClick="() => show3 = !show3">
             </MTextField>
@@ -59,7 +59,7 @@
                 Name="input-10-2"
                 Label="Error"
                 Hint="At least 8 characters"
-                Value="@("Pa")"
+                @bind-Value="@error"
                 Error
                 OnAppendClick="() => show4 = !show4">
             </MTextField>
@@ -74,7 +74,10 @@
     private bool show3;
     private bool show4;
 
-    private string password = "Password";
+    private string hintText = "Password";
+    private string visible = "visible";
+    private string notVisible = "no visible";
+    private string error = "error";
 
     private Func<string, StringBoolean> RequiredRule => val => string.IsNullOrEmpty(val) ? "Required." : true;
     private Func<string, StringBoolean> MinRule => val => val.Length >= 8 ? true : "Min 8 characters";

--- a/src/Masa.Blazor/Components/Autocomplete/MAutocomplete.cs
+++ b/src/Masa.Blazor/Components/Autocomplete/MAutocomplete.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.AspNetCore.Components.Infrastructure;
-using Microsoft.AspNetCore.Components.Web;
-using OneOf.Types;
-
-namespace Masa.Blazor
+﻿namespace Masa.Blazor
 {
     public class MAutocomplete<TItem, TItemValue, TValue> : MSelect<TItem, TItemValue, TValue>, IAutocomplete<TItem, TItemValue, TValue>
     {
@@ -198,8 +194,6 @@ namespace Masa.Blazor
             {
                 await DeleteCurrentItem();
             }
-
-            ValueChangedInternally = true;
 
             InternalSearch = value;
 

--- a/src/Masa.Blazor/Components/FileInput/MFileInput.cs
+++ b/src/Masa.Blazor/Components/FileInput/MFileInput.cs
@@ -260,18 +260,11 @@ namespace Masa.Blazor
                     files.Add(file);
                 }
 
-                InternalValue = (TValue)files;
+                UpdateInternalValue((TValue)files, InternalValueChangeType.Input);
             }
             else
             {
-                if (args.FileCount > 0)
-                {
-                    InternalValue = (TValue)args.File;
-                }
-                else
-                {
-                    InternalValue = default;
-                }
+                UpdateInternalValue(args.FileCount > 0 ? (TValue)args.File : default, InternalValueChangeType.Input);
             }
 
             await OnInput.InvokeAsync(InternalValue);
@@ -310,11 +303,11 @@ namespace Masa.Blazor
             if (Multiple)
             {
                 IList<IBrowserFile> values = new List<IBrowserFile>();
-                InternalValue = (TValue)values;
+                UpdateInternalValue((TValue)values, InternalValueChangeType.InternalOperation);
             }
             else
             {
-                InternalValue = default;
+                UpdateInternalValue(default, InternalValueChangeType.InternalOperation);
             }
 
             await OnClearClick.InvokeAsync(args);

--- a/src/Masa.Blazor/Components/Input/MInput.cs
+++ b/src/Masa.Blazor/Components/Input/MInput.cs
@@ -102,7 +102,7 @@
             }
         }
 
-        protected virtual bool IsDirty => Convert.ToString(LazyValue)?.Length > 0;
+        protected virtual bool IsDirty => Convert.ToString(InternalValue)?.Length > 0;
 
         protected override IEnumerable<Func<TValue, StringBoolean>> InternalRules
         {

--- a/src/Masa.Blazor/Components/Select/MSelect.cs
+++ b/src/Masa.Blazor/Components/Select/MSelect.cs
@@ -755,8 +755,7 @@ public class MSelect<TItem, TItemValue, TValue> : MTextField<TValue>, ISelect<TI
         }
         else if (code == KeyCodes.Enter && MenuListIndex != -1)
         {
-            var item = ComputedItemsIfHideSelected.ElementAtOrDefault(MenuListIndex);
-            await SelectItem(item);
+            await SelectItemByIndex(MenuListIndex);
         }
 
         await SetMenuIndex(MenuListIndex);
@@ -1066,7 +1065,7 @@ public class MSelect<TItem, TItemValue, TValue> : MTextField<TValue>, ISelect<TI
     {
         if (!EqualityComparer<TValue>.Default.Equals(InternalValue, value))
         {
-            InternalValue = value;
+            UpdateInternalValue(value, InternalValueChangeType.InternalOperation);
             if (OnChange.HasDelegate)
             {
                 await OnChange.InvokeAsync(value);

--- a/src/Masa.Blazor/Components/Slider/MSliderBase.cs
+++ b/src/Masa.Blazor/Components/Slider/MSliderBase.cs
@@ -262,8 +262,6 @@ public class MSliderBase<TValue, TNumeric> : MInput<TValue>, ISlider<TValue, TNu
         {
             InternalValue = roundedVal;
         }
-
-        LazyValue = roundedVal;
     }
 
     protected static T ConvertDoubleToTValue<T>(double val)

--- a/src/Masa.Blazor/Components/TextArea/MTextArea.cs
+++ b/src/Masa.Blazor/Components/TextArea/MTextArea.cs
@@ -68,11 +68,6 @@ namespace Masa.Blazor
                 .Watch<bool>(nameof(RowHeight), ReCalculateInputHeight);
         }
 
-        protected override void OnLazyValueChange(string? val)
-        {
-            ReCalculateInputHeight();
-        }
-
         private void ReCalculateInputHeight()
         {
             if (AutoGrow)

--- a/src/Masa.Blazor/Mixins/Selectable/MSelectable.cs
+++ b/src/Masa.Blazor/Mixins/Selectable/MSelectable.cs
@@ -75,7 +75,7 @@ public partial class MSelectable<TValue> : MInput<TValue>, ISelectable<TValue> w
 
         Validate(input);
 
-        InternalValue = input;
+        UpdateInternalValue(input, InternalValueChangeType.InternalOperation);
 
         await TryInvokeFieldChangeOfInputsFilter();
     }

--- a/src/Masa.Blazor/_Imports.cs
+++ b/src/Masa.Blazor/_Imports.cs
@@ -3,6 +3,7 @@ global using BlazorComponent.I18n;
 global using BlazorComponent.JSInterop;
 global using BlazorComponent.Attributes;
 global using BlazorComponent.Web;
+global using BlazorComponent.Components.Input;
 global using Masa.Blazor.Core;
 global using Masa.Blazor.Presets;
 global using Masa.Blazor.Services.Internals;


### PR DESCRIPTION
Now supported:

```razor
<MTextField Value="val1"
            ValueChanged="ValueChanged1"
            UpdateOnChange
            TValue="string">
</MTextField>

<MTextField Value="val2"
            ValueChanged="ValueChanged2"
            TValue="string">
</MTextField>

@code {

    private string val1;
    private string val2;

    private void ValueChanged1(string input)
    {
        if (double.TryParse(input, out var result))
        {
            val1 = result.ToString("0.00");
        }
    }

    private void ValueChanged2(string input)
    {
        val2 = input.Trim(';');
    }

}
```