### PR TITLE
🚸 feat(EnqueuedSnackbars): do not obscure components used for layout

### DIFF
--- a/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor
+++ b/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor
@@ -1,5 +1,4 @@
 ﻿@namespace Masa.Blazor.Presets
-@using Microsoft.Extensions.Options
 @inherits BDomComponentBase
 
 <div class="@CssProvider.GetClass()" style="@CssProvider.GetStyle()">

--- a/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor.cs
+++ b/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor.cs
@@ -1,9 +1,9 @@
-﻿using BlazorComponent.Abstracts;
-
-namespace Masa.Blazor.Presets
+﻿namespace Masa.Blazor.Presets
 {
     public partial class PEnqueuedSnackbars : BDomComponentBase
     {
+        [Inject] private MasaBlazor MasaBlazor { get; set; } = null!;
+
         [Parameter]
         [MasaApiParameter(SnackPosition.BottomCenter)]
         public SnackPosition Position { get; set; } = DEFAULT_SNACK_POSITION;
@@ -45,6 +45,10 @@ namespace Masa.Blazor.Presets
 
         private readonly List<SnackbarOptions> _stack = new();
 
+        private bool IsPositionBottom => Position is SnackPosition.BottomCenter or SnackPosition.BottomLeft or SnackPosition.BottomRight;
+
+        private bool IsPositionTop => Position is SnackPosition.TopCenter or SnackPosition.TopLeft or SnackPosition.TopRight;
+
         protected override void SetComponentClass()
         {
             CssProvider.Apply((cssBuilder) =>
@@ -57,7 +61,12 @@ namespace Masa.Blazor.Presets
                           .AddIf($"{ROOT_CSS}--bottom {ROOT_CSS}--right", () => Position == SnackPosition.BottomRight)
                           .AddIf($"{ROOT_CSS}--bottom {ROOT_CSS}--center", () => Position == SnackPosition.BottomCenter)
                           .AddIf($"{ROOT_CSS}--center", () => Position == SnackPosition.Center);
-            }, styleBuilder => { styleBuilder.AddMaxWidth(MaxWidth); });
+            }, styleBuilder =>
+            {
+                styleBuilder.AddMaxWidth(MaxWidth)
+                    .AddIf($"bottom: {MasaBlazor.Application.Bottom}px", () => IsPositionBottom)
+                    .AddIf($"top: {MasaBlazor.Application.Top}px)", () => IsPositionTop);
+            });
         }
 
         protected override void OnParametersSet()

--- a/src/Masa.Blazor/wwwroot/css/masa-blazor.extend.css
+++ b/src/Masa.Blazor/wwwroot/css/masa-blazor.extend.css
@@ -550,16 +550,15 @@ input[type=number] {
 @media only screen and (max-width: 599.98px) {
     .m-enqueued-snackbars {
         width: 100%;
-        max-width: calc(100% - 2rem) !important;
     }
 }
 
     .m-enqueued-snackbars.m-enqueued-snackbars--top {
-        top: 1rem;
+        top: 0;
     }
     
     .m-enqueued-snackbars.m-enqueued-snackbars--right {
-        right: 1rem;
+        right: 0;
     }
     
     .m-enqueued-snackbars.m-enqueued-snackbars--center {
@@ -568,11 +567,11 @@ input[type=number] {
     }
     
     .m-enqueued-snackbars.m-enqueued-snackbars--bottom {
-        bottom: 1rem;
+        bottom: 0;
     }
     
     .m-enqueued-snackbars.m-enqueued-snackbars--left {
-        left: 1rem;
+        left: 0;
     }
 
     .m-enqueued-snackbars.m-enqueued-snackbars--center:not(.m-enqueued-snackbars--right):not(.m-enqueued-snackbars--left):not(.m-enqueued-snackbars--top):not(.m-enqueued-snackbars--bottom) {


### PR DESCRIPTION
do not obscure components used for layout， such as AppBar and NavigationBottom.