### PR TITLE
🆕 feat(Dialog): add OutcomeContent with a DialogContentContext

### DIFF
--- a/src/Masa.Blazor/Components/Dialog/DialogContentContext.cs
+++ b/src/Masa.Blazor/Components/Dialog/DialogContentContext.cs
@@ -1,0 +1,11 @@
+﻿namespace Masa.Blazor;
+
+public class DialogContentContext
+{
+    public Action Close { get; init; }
+
+    public DialogContentContext(Action close)
+    {
+        Close = close;
+    }
+}

--- a/src/Masa.Blazor/Components/Dialog/MDialog.razor
+++ b/src/Masa.Blazor/Components/Dialog/MDialog.razor
@@ -10,7 +10,8 @@
              style="@CssProvider.GetStyle()"
              id="@Id"
              @ref="Ref"
-             role="dialog">
+             role="dialog"
+             @attributes="@Attributes">
             @if (IsBooted)
             {
                 <div class="@CssProvider.GetClass("content")"
@@ -24,7 +25,7 @@
                                                Class="@CssProvider.GetClass("innerContent")"
                                                Style="@CssProvider.GetStyle("innerContent")"
                                                ReferenceCaptureAction="r => DialogRef = r">
-                            @ChildContent
+                            @(OutcomeContent?.Invoke(_contentContext!) ?? ChildContent)
                         </ShowTransitionElement>
                     </Transition>
 


### PR DESCRIPTION
OutcomeContent which provides DialogContentContext similar to ChildContent allows accessing the OnClose method within the context.

Previously, it was necessary to use an additional variable in the dialog content to close the dialog:

```razor
<MDialog @bind-Value="dialog">
  <ActivatorContent>
    <MButton @attribtues="@context.Attrs">BUTTON</MButton>
  </ActivatorContent>
  <ChildContent>
    <p>content here...</p>
    <MButton OnClick="CloseDialog">Close</MButton>
  </ChildContent>
</MDialog>

@code {

  private bool dialog;

  private void CloseDialog() {
    dialog = false;
  }
}
```

Now you can:

```razor
<MDialog>
  <ActivatorContent>
    <MButton @attribtues="@context.Attrs">BUTTON</MButton>
  </ActivatorContent>
  <OutcomeContent>
    <p>content here...</p>
    <MButton OnClick="@context.Close">Close</MButton>
  </OutcomeContent>
</MDialog>
```
