### PR TITLE
📝 (PWA): cache issue when change the function name in masa-blazor.js

### DIFF
--- a/.github/workflows/wasm-prd.yml
+++ b/.github/workflows/wasm-prd.yml
@@ -14,6 +14,12 @@ jobs:
       with:
         submodules: 'recursive'
     - run: git submodule foreach git checkout main
+    - name: Find and replace
+      uses: jacobtomlinson/gha-find-replace@v3
+      with:
+        find: '\?version='
+        replace: '\?version=${{ github.event.release.tag_name }}'
+        include: 'docs/Masa.Docs.WebAssembly/wwwroot/index.html'
     - name: setting dotnet
       uses: actions/setup-dotnet@v1
       with:

--- a/Masa.Blazor.sln
+++ b/Masa.Blazor.sln
@@ -46,6 +46,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\pr-docs-next.yml = .github\workflows\pr-docs-next.yml
 		.github\workflows\wasm-prd.yml = .github\workflows\wasm-prd.yml
 		.github\workflows\wasm-try.yml = .github\workflows\wasm-try.yml
+		.github\workflows\doc-index-dev.yml = .github\workflows\doc-index-dev.yml
+		.github\workflows\doc-index-prd.yml = .github\workflows\doc-index-prd.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{4234D98C-4DCA-404D-AE9D-EB9DC91FC8DC}"

--- a/docs/Masa.Docs.WebAssembly/wwwroot/index.html
+++ b/docs/Masa.Docs.WebAssembly/wwwroot/index.html
@@ -75,9 +75,9 @@
             document.getElementById("app").classList.add("dark")
         }
     </script>
-    <script src="js/sw.js?v=160"></script>
+    <script src="js/sw.js"></script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
-    <script src="_content/Masa.Blazor/js/masa-blazor.js"></script>
+    <script src="_content/Masa.Blazor/js/masa-blazor.js?version="></script>
     <script src="_content/Masa.Docs.Shared/js/docs.js"></script>
     <script src="_content/Masa.Docs.Shared/js/markdown-it-emoji.min.js"></script>
     <script src="_content/Masa.Docs.Shared/js/markdown-parser.js"></script>
@@ -123,15 +123,6 @@
         }).then(function () {
             Quill.register('modules/blotFormatter', QuillBlotFormatter.default);
         });
-    </script>
-    <script>
-        const version = "1.6.0";
-        const key = "docs-version"
-        const wasmUpdateVersion = localStorage.getItem(key)
-        if (!wasmUpdateVersion || wasmUpdateVersion !== version) {
-            if ('caches' in window) { caches.keys().then(function(cacheNames) { cacheNames.forEach(function(cacheName) { caches.open(cacheName).then(function(cache) { cache.keys().then(function(requests) { requests.forEach(function(request) { cache.delete(request); }); }); }); }); }); }
-            localStorage.setItem(key, version)
-        }
     </script>
 </body>
 

--- a/docs/Masa.Docs.WebAssembly/wwwroot/service-worker.published.js
+++ b/docs/Masa.Docs.WebAssembly/wwwroot/service-worker.published.js
@@ -14,7 +14,16 @@ self.addEventListener('message', event => {
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
 const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/ ];
-const offlineAssetsExclude = [ /^service-worker\.js$/ ];
+const offlineAssetsExclude = [
+  /^service-worker\.js$/,
+  /*
+  * Offline PWA will not work, but good for resolving the issue of cache
+  * */
+  /blazor.boot.json$/, // used to detect whether any of the boot resources have changed
+  /^index\.html$/,
+  /masa-blazor\.js$/,
+  /Masa\.Blazor\.wasm$/
+];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
 const base = "/";


### PR DESCRIPTION
When you update a method name in masa-blazor.js and redeploy the application, it might still call the old method due to Masa.Blazor.wasm using cached data. This can lead to an error message saying "Could not find 'new-method'". Therefore, it's important not to cache Blazor.boot.json and Masa.Blazor.wasm. The masa-blazor.js file is also cached, but you can modify it by changing the script reference in index.html, for example, by adding a version number like masa-blazor.js?versions=v1.6.0.

After redeployment, make sure to check if index.html has changed and avoid caching it as well. Testing has shown that caching of masa-blazor.js should be avoided too; otherwise, errors may occur due to mismatches between the hash of the new blazor.boot.json related to masa-blazor.js and its cached counterpart. However, these errors don't seem to affect program execution.