### PR TITLE
🐛 fix(CarouselItem): the root tag should be `a` when Href is not null

### DIFF
--- a/src/Masa.Blazor/Components/Carousel/MCarousel.razor
+++ b/src/Masa.Blazor/Components/Carousel/MCarousel.razor
@@ -41,7 +41,7 @@
 
     private RenderFragment GenProgress() => __builder =>
     {
-        <MProgressLinear Color="@ProgressColor" Value="@ProgressValue"/>
+        <MProgressLinear Class="m-carousel__progress" Color="@ProgressColor" Value="@ProgressValue"/>
     };
 
 }

--- a/src/Masa.Blazor/Components/Carousel/MCarouselItem.cs
+++ b/src/Masa.Blazor/Components/Carousel/MCarouselItem.cs
@@ -10,8 +10,6 @@ public class MCarouselItem : MWindowItem, IRoutable
 
     [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-    [Parameter] public string? Tag { get; set; }
-
     [Parameter] public string? Target { get; set; }
 
     [Parameter] public string? Src { get; set; }

--- a/src/Masa.Blazor/I18n/EmbeddedLocales.cs
+++ b/src/Masa.Blazor/I18n/EmbeddedLocales.cs
@@ -1,11 +1,12 @@
-﻿using System.Reflection;
+﻿using System.Collections.Concurrent;
+using System.Reflection;
 
 namespace Masa.Blazor.Core.I18n;
 
 internal static class EmbeddedLocales
 {
     private static readonly Dictionary<string, string> s_availableResources;
-    private static readonly Dictionary<CultureInfo, Dictionary<string, string>> s_localeCaches = new();
+    private static readonly ConcurrentDictionary<CultureInfo, Dictionary<string, string>> s_localeCaches = new();
     private static readonly Assembly s_resourcesAssembly = typeof(Masa.Blazor.I18n).Assembly;
 
     static EmbeddedLocales()


### PR DESCRIPTION
Fixes #2249 