### PR TITLE
fix(Sortable): re-sort by `Order` through js-interop when items changed

### DIFF
--- a/src/Masa.Blazor/Components/Sortable/MSortable.razor
+++ b/src/Masa.Blazor/Components/Sortable/MSortable.razor
@@ -3,11 +3,11 @@
 @typeparam TItem
 
 <MElement Class="@GetClass()"
-         Style="@GetStyle()"
-         Tag="@Tag"
-         id="@Id"
-         ReferenceCaptureAction="r => Ref = r"
-         @attributes="@Attributes">
+          Style="@GetStyle()"
+          Tag="@Tag"
+          id="@Id"
+          ReferenceCaptureAction="r => Ref = r"
+          @attributes="@Attributes">
     @GenItems()
 </MElement>
 
@@ -25,10 +25,10 @@
             var dataId = ItemKey?.Invoke(item);
 
             <MElement Tag="@ItemTag"
-                     Class="@GetClass(_block.Element("item").Name, ItemClass)"
-                     Style="@ItemStyle"
-                     @key="@(dataId ?? (object?)item)"
-                     data-id="@dataId">
+                      Class="@GetClass(_block.Element("item").Name, ItemClass)"
+                      Style="@ItemStyle"
+                      @key="@(dataId ?? (object?)item)"
+                      data-id="@dataId">
                 @ChildContent(item)
             </MElement>
         }

--- a/src/Masa.Blazor/Components/Sortable/MSortableProvider.cs
+++ b/src/Masa.Blazor/Components/Sortable/MSortableProvider.cs
@@ -28,7 +28,6 @@ public class MSortableProvider<TItem> : MSortableProviderBase<TItem>
     {
         builder.AddContent(0, sb =>
         {
-            var i = 0;
             foreach (var item in Items)
             {
                 Dictionary<string, object?> attrs = new()
@@ -36,7 +35,7 @@ public class MSortableProvider<TItem> : MSortableProviderBase<TItem>
                     { "data-id", ItemKey(item) }
                 };
                 var context = new SortableItemContext<TItem>(item, attrs);
-                sb.AddContent(i++, ItemContent?.Invoke(context));
+                sb.AddContent(1, ItemContent?.Invoke(context));
             }
         });
     }


### PR DESCRIPTION
When the items change, they should not be rendered in the order of the items. Now, after the items are updated, the UI order should be updated through js-interop based on the `Order` value during the next rendering.