### PR TITLE
🐛 fix(PageStack): GoBackToPageAndReplace has subtle issues

### DIFF
--- a/docs/Masa.Blazor.Docs/Pages/PageStackPage3.razor
+++ b/docs/Masa.Blazor.Docs/Pages/PageStackPage3.razor
@@ -20,7 +20,7 @@
 </a>
 <br />
 <a class="text-decoration-underline"
-   @onclick="@(() => NavController.GoBackToPage("/blazor/examples/page-stack/page2/xyz", "/blazor/examples/page-stack/page2/abc"))">
+   @onclick="@(() => NavController.GoBackToPageAndReplace("/blazor/examples/page-stack/page2/xyz", "/blazor/examples/page-stack/page2/abc"))">
     Go back to page 2 and replace with /abc
 </a>
 

--- a/src/Masa.Blazor/Presets/PageStack/PPageStack.razor.cs
+++ b/src/Masa.Blazor/Presets/PageStack/PPageStack.razor.cs
@@ -131,8 +131,6 @@ public partial class PPageStack : PatternPathComponentBase
     [JSInvokable]
     public void Popstate(string absolutePath)
     {
-        Console.Out.WriteLine("[PageStack] Popstate: " + absolutePath);
-
         if (_uriForPushAndClearStack is not null)
         {
             Push(_uriForPushAndClearStack);


### PR DESCRIPTION
简单来说就是history.go调用和内部pages维护堆栈的执行顺序没按预期发生。现在改为，popstate里执行维护堆栈的逻辑，就确保了先执行history.go调用跳转。