### PR TITLE
🐛 fix(DataTable): ensure group is open by default when not cached

### DIFF
--- a/src/Masa.Blazor/Components/DataTable/MDataTable.razor
+++ b/src/Masa.Blazor/Components/DataTable/MDataTable.razor
@@ -129,6 +129,7 @@
         {
             if (!OpenCache.TryGetValue(group.Key, out var isOpen))
             {
+                isOpen = true;
                 OpenCache[group.Key] = true;
             }
 


### PR DESCRIPTION
Fixes #2349
