### PR TITLE
fix(PageTabs): refactor event binding for PageTabs to improve init logic

### DIFF
--- a/src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs
+++ b/src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs
@@ -46,6 +46,7 @@ public partial class PPageContainer : PatternPathComponentBase
 
     private readonly Block _block = new("p-page-container");
 
+    private bool _eventBound;
     private string? _previousPath;
     private PatternPath? _currentPatternPath;
 
@@ -59,6 +60,8 @@ public partial class PPageContainer : PatternPathComponentBase
     {
         base.OnInitialized();
 
+        BindEvents(ContainerPageTabs);
+
         UpdateCacheRegexes();
 
         var patternPath = GetCurrentPatternPath();
@@ -70,13 +73,6 @@ public partial class PPageContainer : PatternPathComponentBase
             _previousPath = patternPath.AbsolutePath;
         }
 
-        if (ContainerPageTabs != null)
-        {
-            ContainerPageTabs.TabClosed += PageTabsOnTabClosed;
-            ContainerPageTabs.TabReload += PageTabsOnTabReload;
-            ContainerPageTabs.TabsUpdated += PageTabsOnTabsUpdated;
-        }
-
         NavigationManager.LocationChanged += NavigationManagerOnLocationChanged;
     }
 
@@ -84,7 +80,22 @@ public partial class PPageContainer : PatternPathComponentBase
     {
         base.OnParametersSet();
 
+        BindEvents(PageTabs);
+
         UpdateCacheRegexes();
+    }
+
+    private void BindEvents(PPageTabs? component)
+    {
+        if (_eventBound || component is null)
+        {
+            return;
+        }
+        
+        _eventBound = true;
+        component.TabClosed += PageTabsOnTabClosed;
+        component.TabReload += PageTabsOnTabReload;
+        component.TabsUpdated += PageTabsOnTabsUpdated;
     }
 
     private void UpdateCacheRegexes()
@@ -107,20 +118,6 @@ public partial class PPageContainer : PatternPathComponentBase
     protected override IEnumerable<string> BuildComponentClass()
     {
         yield return "p-page-container";
-    }
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        base.OnAfterRender(firstRender);
-
-        if (firstRender)
-        {
-            if (PageTabs == null) return;
-
-            PageTabs.TabClosed += PageTabsOnTabClosed;
-            PageTabs.TabReload += PageTabsOnTabReload;
-            PageTabs.TabsUpdated += PageTabsOnTabsUpdated;
-        }
     }
 
     private void PageTabsOnTabClosed(object? sender, PatternPath e)


### PR DESCRIPTION
Fixes #2393 

This pull request refactors the event binding logic in the `PPageContainer` class to improve maintainability and reduce redundancy. The changes include introducing a new helper method for event binding, removing duplicate event subscriptions, and ensuring events are only bound once.

### Event Binding Refactor:

* Added a new private field `_eventBound` to track whether events have already been bound, preventing duplicate bindings. (`src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs`, [src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.csR49](diffhunk://#diff-219ed87e56ce913949a40a43721895389c311c7febca04c2022b75c48b964cb9R49))
* Introduced a helper method `BindEvents(PPageTabs? component)` to centralize event subscription logic, ensuring it is reusable and concise. (`src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs`, [src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.csL73-R100](diffhunk://#diff-219ed87e56ce913949a40a43721895389c311c7febca04c2022b75c48b964cb9L73-R100))
* Updated the `OnInitialized` and `OnParametersSet` methods to use the new `BindEvents` method, replacing inline event subscription logic. (`src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs`, [[1]](diffhunk://#diff-219ed87e56ce913949a40a43721895389c311c7febca04c2022b75c48b964cb9R63-R64) [[2]](diffhunk://#diff-219ed87e56ce913949a40a43721895389c311c7febca04c2022b75c48b964cb9L73-R100)

### Code Simplification:

* Removed the overridden `OnAfterRender` method, as its event subscription logic is now handled by the `BindEvents` method, streamlining the code. (`src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.cs`, [src/Masa.Blazor/Presets/PageTabs/PageContainer/PPageContainer.razor.csL112-L125](diffhunk://#diff-219ed87e56ce913949a40a43721895389c311c7febca04c2022b75c48b964cb9L112-L125))