### PR TITLE
feat(PageStack): make stack page bar configurable to enhance UI diversity

### DIFF
--- a/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PPageStack-en-US.json
+++ b/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PPageStack-en-US.json
@@ -2,6 +2,7 @@
   "props": {
     "fallbackUri": "In the stack page, if there is no previous page after clicking the return button in the upper left corner, the page to jump to",
     "name": "The unique name of PageStackNavController. Only need to be set when there are multiple stack components in your application",
-    "tabRules": "Set the rules for all tab pages. `Pattern` accepts a regular expression that matches the URL; `Persistent` indicates whether to cache the current tab page state; `Self` can be enabled when the route has parameter matching"
+    "tabRules": "Set the rules for all tab pages. `Pattern` accepts a regular expression that matches the URL; `Persistent` indicates whether to cache the current tab page state; `Self` can be enabled when the route has parameter matching",
+    "appBarAlwaysVisible": "Each page in the stack will have an app bar by default. If set to `false`, only the page that include the [PStackPageBar](/blazor/mobiles/page-stack#pstackpagebar) component will have an app bar."
   }
 }

--- a/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PPageStack-zh-CN.json
+++ b/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PPageStack-zh-CN.json
@@ -2,6 +2,7 @@
   "props": {
     "fallbackUri": "在堆栈页时，点击左上角的返回按钮后如果没有上一页则跳转的页面",
     "name": "PageStackNavController 的唯一名称。仅当你的应用中有多个堆栈组件时才需要设置",
-    "tabRules": "设置所有标签页的规则。`Pattern`接受一个匹配URL的正则表达式；`Persistent`表示是否缓存当前标签页状态；`Self`在当路由存在参数匹配时可启用"
+    "tabRules": "设置所有标签页的规则。`Pattern`接受一个匹配URL的正则表达式；`Persistent`表示是否缓存当前标签页状态；`Self`在当路由存在参数匹配时可启用",
+    "appBarAlwaysVisible": "堆栈中的每个页面默认都会有一个应用栏。如果设置为 `false`，则只有包含 [PStackPageBar](/blazor/mobiles/page-stack#pstackpagebar) 组件的页面才会有应用栏。"
   }
 }

--- a/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PStackPageBar-en-US.json
+++ b/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PStackPageBar-en-US.json
@@ -5,16 +5,12 @@
   "props": {
     "centerTitle": "Determine whether the title is centered",
     "image": "Background image of the title bar",
-    "title": "Title of the title bar",
-    "rerenderKey": "A key to determine whether to force re-render the bar"
+    "title": "Title of the title bar"
   },
   "contents": {
     "actionContent": "Customize the right operation area of the title bar",
     "barContent": "Customize the entire title bar",
     "goBackContent": "Customize the return button area",
     "imageContent": "Customize the background image area"
-  },
-  "methods": {
-    "rerender": "Force to re-render the bar"
   }
 }

--- a/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PStackPageBar-zh-CN.json
+++ b/docs/Masa.Blazor.Docs/wwwroot/data/apis/page-stack/PStackPageBar-zh-CN.json
@@ -5,16 +5,12 @@
   "props": {
     "centerTitle": "居中显示标题",
     "image": "标题栏背景图片",
-    "title": "标题栏标题",
-    "rerenderKey": "强制刷新标识"
+    "title": "标题栏标题"
   },
   "contents": {
     "actionContent": "自定义标题栏右侧操作区域",
     "barContent": "自定义整个标题栏",
     "goBackContent": "自定义返回按钮区域",
     "imageContent": "自定义标题栏背景图片"
-  },
-  "methods": {
-    "rerender": "强制刷新"
   }
 }

--- a/docs/Masa.Blazor.Docs/wwwroot/data/page-to-api.json
+++ b/docs/Masa.Blazor.Docs/wwwroot/data/page-to-api.json
@@ -146,7 +146,7 @@
   "page-stack": [
     "PPageStack",
     "PPageStackTab",
-    "PStackPageBarInit",
+    "PStackPageBar",
     "PageStackNavController"
   ],
   "page-tabs": [

--- a/docs/Masa.Blazor.Docs/wwwroot/pages/mobiles/page-stack/en-US.md
+++ b/docs/Masa.Blazor.Docs/wwwroot/pages/mobiles/page-stack/en-US.md
@@ -165,20 +165,22 @@ The `a` tag has an unavoidable problem: continuous clicks will cause multiple tr
   }
   ```
 
-### PStackPageBarInit
+### PStackPageBar {released-on=v1.10.0}
+
+<app-alert type="error" content="The **PStackPageBarInit** component has been deprecated, please use the **PStackPageBar** component instead."></app-alert>
 
 Used to initialize the AppBar at the top of the stack page. Most properties are consistent
 with [MAppBar](/blazor/components/app-bars).
 
 ```razor MyStackPage.razor
-<PStackPageBarInit Title="Order detail"
-                   CenterTitle 
-                   Flat
-                   Color="primary">
-</PStackPageBarInit>
+<PStackPageBar Title="Order detail"
+               CenterTitle 
+               Flat
+               Color="primary">
+</PStackPageBar>
 ```
 
-The following are the parameters of **PStackPageBarInit** that are different from **MAppBar**:
+The following are the parameters of **PStackPageBar** that are different from **MAppBar**:
 
 | Main parameters | Description                                                                                                |
 |-----------------|------------------------------------------------------------------------------------------------------------|
@@ -188,7 +190,6 @@ The following are the parameters of **PStackPageBarInit** that are different fro
 | `BarContent`    | Custom the entire content.                                                                                 |
 | `GoBackContent` | Custom the back button.                                                                                    |
 | `ActionContent` | Set the right operation area.                                                                              |
-| `RerenderKey`   | Used for forced rendering. When the content of `BarContent` cannot be refreshed after use, you can use it. |
 
 ### PStackPageBase
 

--- a/docs/Masa.Blazor.Docs/wwwroot/pages/mobiles/page-stack/zh-CN.md
+++ b/docs/Masa.Blazor.Docs/wwwroot/pages/mobiles/page-stack/zh-CN.md
@@ -163,19 +163,21 @@ builder.Services
   }
   ```
 
-### PStackPageBarInit
+### PStackPageBar {released-on=v1.10.0}
+
+<app-alert type="error" content="**PStackPageBarInit** 组件已废弃，请使用 **PStackPageBar** 组件。"></app-alert>
 
 初始化堆栈页面顶部的 AppBar。大部分属性和 [MAppBar](/blazor/components/app-bars)一致。
 
 ```razor MyStackPage.razor
-<PStackPageBarInit Title="Order detail"
-                   CenterTitle 
-                   Flat
-                   Color="primary">
-</PStackPageBarInit>
+<PStackPageBar Title="Order detail"
+               CenterTitle 
+               Flat
+               Color="primary">
+</PStackPageBar>
 ```
 
-以下是 **PStackPageBarInit** 不同于 **MAppBar** 的参数：
+以下是 **PStackPageBar** 不同于 **MAppBar** 的参数：
 
 | 参数名称            | 说明                                  |
 |-----------------|-------------------------------------|
@@ -185,7 +187,6 @@ builder.Services
 | `BarContent`    | 自定义整个内容。                            |
 | `GoBackContent` | 自定义返回按钮。                            |
 | `ActionContent` | 设置右侧操作区域。                           |
-| `RerenderKey`   | 用于强制渲染。当使用`BarContent`后其内容无法刷新时可使用。 |
 
 ### PStackPageBase
 

--- a/src/Masa.Blazor.Docs.ApiGenerator/ApiGenerator.cs
+++ b/src/Masa.Blazor.Docs.ApiGenerator/ApiGenerator.cs
@@ -403,6 +403,7 @@ public class ApiGenerator : IIncrementalGenerator
         {
             nameof(String)  => "string",
             nameof(Boolean) => "bool",
+            nameof(Single)  => "float",
             nameof(Double)  => "double",
             nameof(Int32)   => "int",
             nameof(Int64)   => "long",

--- a/src/Masa.Blazor.Docs.ComponentApiGenerator/ComponentApiGenerator.cs
+++ b/src/Masa.Blazor.Docs.ComponentApiGenerator/ComponentApiGenerator.cs
@@ -347,6 +347,7 @@ public class ComponentApiGenerator : IIncrementalGenerator
         {
             nameof(String)  => "string",
             nameof(Boolean) => "bool",
+            nameof(Single)  => "float",
             nameof(Double)  => "double",
             nameof(Int32)   => "int",
             nameof(Int64)   => "long",

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor
@@ -19,7 +19,8 @@
         var isTop = i == Pages.Count - 1;
         var canRender = isTop && NavigationManager.GetAbsolutePath().Equals(pageData.AbsolutePath, StringComparison.OrdinalIgnoreCase);
 
-        <PPageStackItem Data="pageData"
+        <PPageStackItem AppBarVisible="@AppBarAlwaysVisible"
+                        Data="pageData"
                         CanRender="@canRender"
                         OnGoBack="@HandleOnPrevious"
                         @key="@pageData.Id">

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor.cs
@@ -25,6 +25,14 @@ public partial class PPageStack: MasaComponentBase
     [MasaApiParameter(defaultValue: DefaultFallbackUri)]
     public string? FallbackUri { get; set; } = DefaultFallbackUri;
 
+    /// <summary>
+    /// Each page in the stack will have an app bar by default. If set to false,
+    /// only the page that include the <see cref="PStackPageBar"/> component will have an app bar.
+    /// </summary>
+    [Parameter]
+    [MasaApiParameter(true, "v1.10.0")]
+    public bool AppBarAlwaysVisible { get; set; } = true;
+
     private PageStackNavController? InternalPageStackNavController { get; set; }
 
     private const int DelayForPageClosingAnimation = 300;

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor
@@ -10,17 +10,20 @@
          NoPersistentAnimation
          NoOutsideClick
          ContentAttributes="@(new Dictionary<string, object> { { "page-stack-id", Data.Id } })"
-         @ref="dialog">
-    <MShouldRender Value="@CanRender">
-        <CascadingValue Value="this" IsFixed>
+         @ref="_dialog">
+    <CascadingValue Value="this" IsFixed>
+        @if (IncludingAppBar)
+        {
             <MAppBar Class="@GetClass(_block.Element("bar").Name, AppBarClass)"
                      Style="@AppBarStyle"
+                     Collapse="@AppBarCollapse"
                      Color="@AppBarColor"
                      Dense="@AppBarDense"
                      Short="@AppBarShort"
                      ElevateOnScroll="@ElevateOnScroll"
                      ExtensionContent="@ExtensionContent"
                      ExtensionHeight="@ExtensionHeight"
+                     Elevation="@Elevation"
                      Fixed
                      Flat="@AppBarFlat"
                      Height="@(AppBarHeight == 0 ? null : AppBarHeight)"
@@ -28,8 +31,7 @@
                      ShrinkOnScroll="@ShrinkOnScroll"
                      Src="@AppBarImage"
                      ScrollTarget="@Data.Selector"
-                     Light="@AppBarLight"
-                     Dark="@AppBarDark">
+                     Theme="@AppBarTheme">
                 <ChildContent>
                     @if (AppBarContent is not null)
                     {
@@ -52,7 +54,7 @@
                             @AppBarTitle
                         </MAppBarTitle>
 
-                        <MSpacer />
+                        <MSpacer/>
 
                         <div class="@_block.Element("actions")">
                             @ActionContent
@@ -60,10 +62,11 @@
                     }
                 </ChildContent>
             </MAppBar>
-            <div class="@_block.Element("content")"
-                 style="@($"--m-page-stack-item-bar-height: {ComputedBarHeight}px;")">
-                @ChildContent
-            </div>
-        </CascadingValue>
-    </MShouldRender>
+        }
+
+        <div class="@_block.Element("content")"
+             style="@($"--m-page-stack-item-bar-height: {ComputedBarHeight}px;")">
+            @ChildContent
+        </div>
+    </CascadingValue>
 </MDialog>

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
@@ -41,13 +41,12 @@ public partial class PPageStackItem : MasaComponentBase
     internal bool ElevateOnScroll { get; set; } = true;
     internal bool ShrinkOnScroll { get; set; }
     internal string? AppBarTheme { get; set; }
-    internal bool Overlap { get; set; }
 
     private int ComputedBarHeight
     {
         get
         {
-            if (Overlap || !IncludingAppBar)
+            if (!IncludingAppBar)
             {
                 return 0;
             }

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
@@ -38,7 +38,7 @@ public partial class PPageStackItem : MasaComponentBase
     internal string? AppBarTitle { get; set; }
     internal string? AppBarImage { get; set; }
     internal bool CenterTitle { get; set; }
-    internal bool ElevateOnScroll { get; set; } = true;
+    internal bool ElevateOnScroll { get; set; }
     internal bool ShrinkOnScroll { get; set; }
     internal string? AppBarTheme { get; set; }
 

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor.cs
@@ -11,19 +11,26 @@ public partial class PPageStackItem : MasaComponentBase
     [Parameter] public bool CanRender { get; set; }
 
     [Parameter] public EventCallback OnGoBack { get; set; }
+    
+    [Parameter] public bool AppBarVisible { get; set; }
 
     private TouchJSObjectResult? _touchJSObjectResult;
 
     private string Transition => Data.DisableTransition ? string.Empty : "dialog-right-transition";
 
+    private bool IncludingAppBar => AppBarVisible || Visible;
+
+    internal bool Visible { get; set; }
     internal RenderFragment<PageStackGoBackContext>? AppBarContent { get; set; }
     internal RenderFragment<PageStackGoBackContext>? GoBackContent { get; set; }
     internal RenderFragment<Dictionary<string, object?>>? ImageContent { get; set; }
     internal RenderFragment? ExtensionContent { get; set; }
     internal int ExtensionHeight { get; set; } = 48;
     internal string? AppBarColor { get; set; }
+    internal bool AppBarCollapse { get; set; }
     internal string? AppBarClass { get; set; }
     internal bool AppBarFlat { get; set; }
+    internal StringNumber? Elevation { get; set; }
     internal int AppBarHeight { get; set; }
     internal bool AppBarDense { get; set; }
     internal bool AppBarShort { get; set; }
@@ -31,15 +38,20 @@ public partial class PPageStackItem : MasaComponentBase
     internal string? AppBarTitle { get; set; }
     internal string? AppBarImage { get; set; }
     internal bool CenterTitle { get; set; }
-    internal bool ElevateOnScroll { get; set; }
+    internal bool ElevateOnScroll { get; set; } = true;
     internal bool ShrinkOnScroll { get; set; }
-    internal bool AppBarLight { get; set; }
-    internal bool AppBarDark { get; set; }
+    internal string? AppBarTheme { get; set; }
+    internal bool Overlap { get; set; }
 
     private int ComputedBarHeight
     {
         get
         {
+            if (Overlap || !IncludingAppBar)
+            {
+                return 0;
+            }
+
             var height = ComputeBarHeight();
 
             if (ExtensionContent is not null)
@@ -76,8 +88,7 @@ public partial class PPageStackItem : MasaComponentBase
     private static Block _block = new("m-page-stack-item");
     private ModifierBuilder _modifierBuilder = _block.CreateModifierBuilder();
 
-    private bool _hasRendered;
-    private MDialog? dialog;
+    private MDialog? _dialog;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -85,14 +96,14 @@ public partial class PPageStackItem : MasaComponentBase
 
         if (firstRender)
         {
-            _ = RetryIf(UseTouchAsync, () => dialog?.ContentRef.Context is null);
+            _ = RetryIf(UseTouchAsync, () => _dialog?.ContentRef.Context is null);
         }
     }
 
     private async Task UseTouchAsync()
     {
         var touch = new Touch(Js, OnTouchEnd);
-        _touchJSObjectResult = await touch.UseTouchAsync(dialog!.ContentRef, GetTouchState());
+        _touchJSObjectResult = await touch.UseTouchAsync(_dialog!.ContentRef, GetTouchState());
     }
 
     private TouchState GetTouchState()

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackLink.razor
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackLink.razor
@@ -32,9 +32,6 @@ else
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object?> Attributes { get; set; } = [];
 
-    private CancellationTokenSource? _cts;
-    private long _time;
-
     private void OnClick()
     {
         if (Href is null)

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
@@ -42,7 +42,7 @@ public class PStackPageBar : IComponent
 
     [Parameter] public int ExtensionHeight { get; set; } = 48;
 
-    [Parameter] public bool ElevateOnScroll { get; set; } = true;
+    [Parameter] public bool ElevateOnScroll { get; set; }
 
     [Parameter] public bool ShrinkOnScroll { get; set; }
 

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
@@ -48,11 +48,6 @@ public class PStackPageBar : IComponent
 
     [Parameter] public string? Theme { get; set; }
 
-    /// <summary>
-    /// Determines whether the bar overlaps the content below it.
-    /// </summary>
-    [Parameter] public bool Overlap { get; set; }
-
     [Parameter] public StringNumber? Elevation { get; set; }
 
     public void Attach(RenderHandle renderHandle)
@@ -107,7 +102,6 @@ public class PStackPageBar : IComponent
             PageStackItem.ShrinkOnScroll = ShrinkOnScroll;
             PageStackItem.AppBarTheme = Theme;
             PageStackItem.ActionContent = ActionContent;
-            PageStackItem.Overlap = Overlap;
             PageStackItem.AppBarCollapse = Collapse;
         }
     }

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBar.cs
@@ -2,18 +2,17 @@
 
 namespace Masa.Blazor.Presets;
 
-[Obsolete("This component is deprecated, please use PStackPageBar instead.")]
-public class PStackPageBarInit : IComponent
+public class PStackPageBar : IComponent
 {
     [CascadingParameter] protected IDefaultsProvider? DefaultsProvider { get; set; }
 
     [CascadingParameter] private PPageStackItem? PageStackItem { get; set; }
 
-    [Parameter] public string? RerenderKey { get; set; }
-
     [Parameter] public string? Class { get; set; }
 
     [Parameter] public string? Style { get; set; }
+
+    [Parameter] public bool Collapse { get; set; }
 
     [Parameter] public string? Color { get; set; }
 
@@ -47,12 +46,14 @@ public class PStackPageBarInit : IComponent
 
     [Parameter] public bool ShrinkOnScroll { get; set; }
 
-    [Parameter] public bool Dark { get; set; }
+    [Parameter] public string? Theme { get; set; }
 
-    [Parameter] public bool Light { get; set; }
+    /// <summary>
+    /// Determines whether the bar overlaps the content below it.
+    /// </summary>
+    [Parameter] public bool Overlap { get; set; }
 
-    private bool _init;
-    private string? _prevRerenderKey;
+    [Parameter] public StringNumber? Elevation { get; set; }
 
     public void Attach(RenderHandle renderHandle)
     {
@@ -67,15 +68,8 @@ public class PStackPageBarInit : IComponent
             return Task.CompletedTask;
         }
 
-        var hasRerenderKey = parameters.TryGetValue<string>(nameof(RerenderKey), out var rerenderKey);
-
-        if (!_init || (hasRerenderKey && _prevRerenderKey != rerenderKey))
-        {
-            _init = true;
-            _prevRerenderKey = rerenderKey;
-            SetParameters();
-            Rerender();
-        }
+        SetParameters();
+        Rerender();
 
         return Task.CompletedTask;
 
@@ -83,7 +77,7 @@ public class PStackPageBarInit : IComponent
         {
             if (parameters.TryGetValue<IDefaultsProvider>(nameof(DefaultsProvider), out var defaultsProvider)
                 && defaultsProvider.Defaults is not null
-                && defaultsProvider.Defaults.TryGetValue(nameof(PStackPageBarInit), out var dictionary)
+                && defaultsProvider.Defaults.TryGetValue(nameof(PStackPageBar), out var dictionary)
                 && dictionary is not null)
             {
                 var defaults = ParameterView.FromDictionary(dictionary);
@@ -100,6 +94,7 @@ public class PStackPageBarInit : IComponent
             PageStackItem.ImageContent = ImageContent;
             PageStackItem.AppBarColor = Color;
             PageStackItem.AppBarClass = Class;
+            PageStackItem.Elevation = Elevation;
             PageStackItem.AppBarStyle = Style;
             PageStackItem.AppBarHeight = Height;
             PageStackItem.AppBarFlat = Flat;
@@ -110,13 +105,14 @@ public class PStackPageBarInit : IComponent
             PageStackItem.AppBarImage = Image;
             PageStackItem.ElevateOnScroll = ElevateOnScroll;
             PageStackItem.ShrinkOnScroll = ShrinkOnScroll;
-            PageStackItem.AppBarTheme = Dark ? "dark" : "light";
+            PageStackItem.AppBarTheme = Theme;
             PageStackItem.ActionContent = ActionContent;
+            PageStackItem.Overlap = Overlap;
+            PageStackItem.AppBarCollapse = Collapse;
         }
     }
 
-    [MasaApiPublicMethod]
-    public void Rerender()
+    private void Rerender()
     {
         PageStackItem?.Render();
     }

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBase.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PStackPageBase.cs
@@ -34,7 +34,7 @@ public class PStackPageBase : ComponentBase, IAsyncDisposable
             PageStack.Pages.PagePushed += PagesOnPagePushed;
         }
     }
-
+    
     private void PagesOnPagePushed(object? sender, StackPagesPushedEventArgs e)
     {
         if (Page is null)

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/TabbedPage.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/TabbedPage.cs
@@ -1,8 +1,0 @@
-﻿namespace Masa.Blazor.Presets.PageStack;
-
-public class TabbedPage
-{
-    public string Pattern { get; set; }
-    
-    public DateTime CreatedAt { get; set; }
-}


### PR DESCRIPTION
New:
- **PStackPageBar**: This replaces the old PStackPageBarInit and no longer requires a RerenderKey to notify the bar to re-render.
- `AppBarAlwaysVisible` parameter, which defaults to `true`, meaning the App bar will be displayed on every stack page. When set to `false`, only the stack pages marked with the PStackPageBar component will show the App bar.