### PR TITLE
🐛 fix(EnqueuedSnackbars): remove unnecessary semaphore release for duplicate messages

### DIFF
--- a/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor.cs
+++ b/src/Masa.Blazor/Presets/EnqueuedSnackbars/PEnqueuedSnackbars.razor.cs
@@ -136,7 +136,6 @@ namespace Masa.Blazor.Presets
             {
                 if (IsDuplicateMessage(config))
                 {
-                    _semaphore.Release();
                     return;
                 }
 


### PR DESCRIPTION
Fixes #2487 