### PR TITLE
feat: add ShouldRenderWhenInactive parameter to allow rendering when inactive

### DIFF
--- a/src/Masa.Blazor/Components/Dialog/MDialog.razor
+++ b/src/Masa.Blazor/Components/Dialog/MDialog.razor
@@ -26,7 +26,7 @@
                                                Style="@GetStyle()"
                                                ReferenceCaptureAction="r => DialogRef = r"
                                                tabindex="@(IsActive ? 0 : null)">
-                            <MShouldRender Value="@IsActive">
+                            <MShouldRender Value="@(ShouldRenderWhenInactive || IsActive)">
                                 @(OutcomeContent?.Invoke(_contentContext!) ?? ChildContent)
                             </MShouldRender>
                         </ShowTransitionElement>

--- a/src/Masa.Blazor/Components/Dialog/MDialog.razor.cs
+++ b/src/Masa.Blazor/Components/Dialog/MDialog.razor.cs
@@ -73,6 +73,14 @@ namespace Masa.Blazor
         [MasaApiParameter(ReleasedIn = "v1.8.0")]
         public bool DisableAutoFocus { get; set; }
 
+        /// <summary>
+        /// Re-render requests will also be responded to when inactive.
+        /// By default, only active window item will be rendered.
+        /// </summary>
+        [Parameter]
+        [MasaApiParameter(ReleasedIn = "v1.10.3")]
+        public bool ShouldRenderWhenInactive { get; set; }
+
         private readonly HashSet<IDependent> _dependents = new();
 
         private bool _attached;

--- a/src/Masa.Blazor/Components/Dialog/MDialog.razor.cs
+++ b/src/Masa.Blazor/Components/Dialog/MDialog.razor.cs
@@ -75,7 +75,7 @@ namespace Masa.Blazor
 
         /// <summary>
         /// Re-render requests will also be responded to when inactive.
-        /// By default, only active window item will be rendered.
+        /// By default, only active dialog will be rendered.
         /// </summary>
         [Parameter]
         [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor
+++ b/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor
@@ -11,7 +11,7 @@
                                id="@Id"
                                @attributes="@Attributes">
             <div class="@_block.Element("wrap")">
-                <MShouldRender Value="@_isActive">
+                <MShouldRender Value="@(ShouldRenderWhenInactive || _isActive)">
                     @ChildContent
                 </MShouldRender>
             </div>

--- a/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor.cs
+++ b/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor.cs
@@ -8,6 +8,14 @@ public partial class MExpansionPanelContent : MasaComponentBase
 
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Re-render requests will also be responded to when inactive.
+    /// By default, only active window item will be rendered.
+    /// </summary>
+    [Parameter]
+    [MasaApiParameter(ReleasedIn = "v1.10.3")]
+    public bool ShouldRenderWhenInactive { get; set; }
+
     private bool _isBooted;
     private bool _booting;
     private bool _isActive;

--- a/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor.cs
+++ b/src/Masa.Blazor/Components/ExpansionPanels/MExpansionPanelContent.razor.cs
@@ -10,7 +10,7 @@ public partial class MExpansionPanelContent : MasaComponentBase
 
     /// <summary>
     /// Re-render requests will also be responded to when inactive.
-    /// By default, only active window item will be rendered.
+    /// By default, only active expansion panel content will be rendered.
     /// </summary>
     [Parameter]
     [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/List/MListGroup.razor
+++ b/src/Masa.Blazor/Components/List/MListGroup.razor
@@ -33,7 +33,7 @@
                 <ExpandTransition>
                     <ShowTransitionElement Value="IsActive"
                                            Class="@_block.Element("items").Name">
-                        <MShouldRender Value="@IsActive">
+                        <MShouldRender Value="@(ShouldRenderWhenInactive || IsActive)">
                             @ChildContent
                         </MShouldRender>
                     </ShowTransitionElement>

--- a/src/Masa.Blazor/Components/List/MListGroup.razor.cs
+++ b/src/Masa.Blazor/Components/List/MListGroup.razor.cs
@@ -54,7 +54,7 @@ public partial class MListGroup : MasaComponentBase
 
     /// <summary>
     /// Re-render requests will also be responded to when inactive.
-    /// By default, only active window item will be rendered.
+    /// By default, only active list group will be rendered.
     /// </summary>
     [Parameter]
     [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/List/MListGroup.razor.cs
+++ b/src/Masa.Blazor/Components/List/MListGroup.razor.cs
@@ -52,6 +52,14 @@ public partial class MListGroup : MasaComponentBase
 
     [Parameter] public bool Eager { get; set; }
 
+    /// <summary>
+    /// Re-render requests will also be responded to when inactive.
+    /// By default, only active window item will be rendered.
+    /// </summary>
+    [Parameter]
+    [MasaApiParameter(ReleasedIn = "v1.10.3")]
+    public bool ShouldRenderWhenInactive { get; set; }
+
     private readonly Dictionary<string, IDictionary<string, object?>> _defaults
         = new() { [nameof(MListItem)] = new Dictionary<string, object?>() };
 

--- a/src/Masa.Blazor/Components/Menu/MMenu.razor
+++ b/src/Masa.Blazor/Components/Menu/MMenu.razor
@@ -43,7 +43,7 @@
                                            id="@_contentId"
                                            onscroll="@OnScroll"
                                            ReferenceCaptureAction="el => ContentElement = el">
-                        <MShouldRender Value="@IsActive">
+                        <MShouldRender Value="@(ShouldRenderWhenInactive || IsActive)">
                             @ChildContent
                         </MShouldRender>
                     </ShowTransitionElement>

--- a/src/Masa.Blazor/Components/Menu/MMenu.razor.cs
+++ b/src/Masa.Blazor/Components/Menu/MMenu.razor.cs
@@ -47,6 +47,14 @@ namespace Masa.Blazor
         [MasaApiParameter(ReleasedIn = "v1.8.0")]
         public ScrollStrategy ScrollStrategy { get; set; } = ScrollStrategy.Reposition;
 
+        /// <summary>
+        /// Re-render requests will also be responded to when inactive.
+        /// By default, only active window item will be rendered.
+        /// </summary>
+        [Parameter]
+        [MasaApiParameter(ReleasedIn = "v1.10.3")]
+        public bool ShouldRenderWhenInactive { get; set; }
+
         private static Block _block = new("m-menu");
         private ModifierBuilder _modifierBuilder = _block.CreateModifierBuilder();
         private ModifierBuilder _contentModifierBuilder = _block.Element("content").CreateModifierBuilder();

--- a/src/Masa.Blazor/Components/Menu/MMenu.razor.cs
+++ b/src/Masa.Blazor/Components/Menu/MMenu.razor.cs
@@ -49,7 +49,7 @@ namespace Masa.Blazor
 
         /// <summary>
         /// Re-render requests will also be responded to when inactive.
-        /// By default, only active window item will be rendered.
+        /// By default, only active menu will be rendered.
         /// </summary>
         [Parameter]
         [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/Stepper/MStepperContent.razor
+++ b/src/Masa.Blazor/Components/Stepper/MStepperContent.razor
@@ -38,7 +38,7 @@
         <div class="@_wrapperElement.AppendClasses(("active", IsActive))"
              style="@style"
              @ref="_wrapper">
-            <MShouldRender Value="@IsActive">
+            <MShouldRender Value="@(ShouldRenderWhenInactive || IsActive)">
                 @ChildContent
             </MShouldRender>
         </div>

--- a/src/Masa.Blazor/Components/Stepper/MStepperContent.razor.cs
+++ b/src/Masa.Blazor/Components/Stepper/MStepperContent.razor.cs
@@ -14,6 +14,14 @@ public partial class MStepperContent : MasaComponentBase
 
     [Parameter] public bool Eager { get; set; }
 
+    /// <summary>
+    /// Re-render requests will also be responded to when inactive.
+    /// By default, only active window item will be rendered.
+    /// </summary>
+    [Parameter]
+    [MasaApiParameter(ReleasedIn = "v1.10.3")]
+    public bool ShouldRenderWhenInactive { get; set; }
+
     private bool _booting;
     private bool _firstRender = true;
     private StringNumber _height = 0;

--- a/src/Masa.Blazor/Components/Stepper/MStepperContent.razor.cs
+++ b/src/Masa.Blazor/Components/Stepper/MStepperContent.razor.cs
@@ -16,7 +16,7 @@ public partial class MStepperContent : MasaComponentBase
 
     /// <summary>
     /// Re-render requests will also be responded to when inactive.
-    /// By default, only active window item will be rendered.
+    /// By default, only active stepper content will be rendered.
     /// </summary>
     [Parameter]
     [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/Tooltip/MTooltip.razor
+++ b/src/Masa.Blazor/Components/Tooltip/MTooltip.razor
@@ -44,7 +44,7 @@
                                        Class="@css"
                                        Style="@style"
                                        ReferenceCaptureAction="r => ContentElement = r">
-                    <MShouldRender Value="@IsActive">
+                    <MShouldRender Value="@(ShouldRenderWhenInactive || IsActive)">
                         @(ChildContent ?? (RenderFragment)(b => b.AddContent(0, Text)))
                     </MShouldRender>
                 </ShowTransitionElement>

--- a/src/Masa.Blazor/Components/Tooltip/MTooltip.razor.cs
+++ b/src/Masa.Blazor/Components/Tooltip/MTooltip.razor.cs
@@ -31,6 +31,14 @@ namespace Masa.Blazor
         [MasaApiParameter(ReleasedIn = "v1.9.0")]
         public string? Text { get; set; }
 
+        /// <summary>
+        /// Re-render requests will also be responded to when inactive.
+        /// By default, only active window item will be rendered.
+        /// </summary>
+        [Parameter]
+        [MasaApiParameter(ReleasedIn = "v1.10.3")]
+        public bool ShouldRenderWhenInactive { get; set; }
+
         protected override string DefaultAttachSelector => Permanent ? ".m-application__permanent" : ".m-application";
 
         private static Block _block = new("m-tooltip");

--- a/src/Masa.Blazor/Components/Tooltip/MTooltip.razor.cs
+++ b/src/Masa.Blazor/Components/Tooltip/MTooltip.razor.cs
@@ -33,7 +33,7 @@ namespace Masa.Blazor
 
         /// <summary>
         /// Re-render requests will also be responded to when inactive.
-        /// By default, only active window item will be rendered.
+        /// By default, only active tooltip will be rendered.
         /// </summary>
         [Parameter]
         [MasaApiParameter(ReleasedIn = "v1.10.3")]

--- a/src/Masa.Blazor/Components/Window/MWindowItem.razor
+++ b/src/Masa.Blazor/Components/Window/MWindowItem.razor
@@ -16,7 +16,7 @@
                                ReferenceCaptureAction="r => Ref = r"
                                Tag="@Tag"
                                @attributes="@Attributes">
-            <MShouldRender Value="@InternalIsActive">
+            <MShouldRender Value="@(ShouldRenderWhenInactive || InternalIsActive)">
                 @GenChildContent()
             </MShouldRender>
         </ShowTransitionElement>

--- a/src/Masa.Blazor/Components/Window/MWindowItem.razor.cs
+++ b/src/Masa.Blazor/Components/Window/MWindowItem.razor.cs
@@ -24,6 +24,14 @@ public partial class MWindowItem : MGroupItem<MItemGroupBase>
     [Parameter] public bool Eager { get; set; }
 
     /// <summary>
+    /// Re-render requests will also be responded to when inactive.
+    /// By default, only active window item will be rendered.
+    /// </summary>
+    [Parameter]
+    [MasaApiParameter(ReleasedIn = "v1.10.3")]
+    public bool ShouldRenderWhenInactive { get; set; }
+
+    /// <summary>
     /// Internal use
     /// </summary>
     public virtual string Tag { get; set; }


### PR DESCRIPTION
Previously, a version added the functionality of not rendering components with an "active/inactive" status unless they were activated, implemented through the ShouldRender component. Now, it appears that there are still some scenarios where "always renderable" is needed. This pull request introduces a new parameter named `ShouldRenderWhenInactive` that allows manually disabling the aforementioned functionality.

Related issue: #2390